### PR TITLE
Fixed bug in statix where grunt serve fails due to .interfaceType not being found

### DIFF
--- a/assets/src/scss/styleguide.scss
+++ b/assets/src/scss/styleguide.scss
@@ -1,3 +1,9 @@
+// @Author: Rob Harris <robharris>
+// @Date:   9th June 2017, 1:33:28 pm
+// @Email:  rob.harris@analogfolk.com
+// @Last modified by:   robharris
+// @Last modified time: 9th June 2017, 1:34:12 pm
+
 /**
  * Setup styleguide imports
  */
@@ -204,8 +210,8 @@ code {
 
 	&:after {
 		display: block;
-		@extend .interfaceType;
-		@extend .interfaceType-subtle;
+		@extend .sg-interfaceType;
+		@extend .interfaceType-subtle !optional;
 		@include font-size(16);
 		margin-top: 5px;
 		border-top: 1px solid #ddd;

--- a/assets/src/scss/styleguide.scss
+++ b/assets/src/scss/styleguide.scss
@@ -1,9 +1,3 @@
-// @Author: Rob Harris <robharris>
-// @Date:   9th June 2017, 1:33:28 pm
-// @Email:  rob.harris@analogfolk.com
-// @Last modified by:   robharris
-// @Last modified time: 9th June 2017, 1:34:12 pm
-
 /**
  * Setup styleguide imports
  */


### PR DESCRIPTION
Hi all,

I was running into an error with the grunt serve on statix and was getting the below error:

Error: ".sg-typeSpecimen:after" failed to @extend ".interfaceType".
The selector ".interfaceType" was not found.
Use "@extend .interfaceType !optional" if the extend should be able to fail.
on line 207 of assets/src/scss/styleguide.scss
@extend .interfaceType;

This also happened for **interfaceType-subtle** too.

The fix that I have committed was to rename **interfaceType** to **sg-interfaceType** as there is a class declaration for this. With **interfaceType-subtle** I couldn't find a class, so I added the !optional flag so that the grunt serve can continue on its merry way.

Hope it helps.

Rob

